### PR TITLE
Update comments and example code about the network address

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,21 @@ go get -u github.com/rpcxio/gomemcached
 And register handlers.
 
 ```go
-    addr = "127.0.0.1:" + strconv.Itoa(port)
-	mockServer = NewServer(addr)
-	mockServer.RegisterFunc("get", DefaultGet)
-	mockServer.RegisterFunc("gets", DefaultGet)
-	mockServer.RegisterFunc("set", DefaultSet)
-	mockServer.RegisterFunc("delete", DefaultDelete)
-	mockServer.RegisterFunc("incr", DefaultIncr)
-	mockServer.RegisterFunc("flush_all", DefaultFlushAll)
-	mockServer.RegisterFunc("version", DefaultVersion)
-	mockServer.Start()
+addr := "127.0.0.1:" + strconv.Itoa(port)
+// or use unix domain socket, like:
+// addr := "unix:///tmp/memcached.sock"
+
+mockServer := NewServer(addr)
+
+mockServer.RegisterFunc("get", DefaultGet)
+mockServer.RegisterFunc("gets", DefaultGet)
+mockServer.RegisterFunc("set", DefaultSet)
+mockServer.RegisterFunc("delete", DefaultDelete)
+mockServer.RegisterFunc("incr", DefaultIncr)
+mockServer.RegisterFunc("flush_all", DefaultFlushAll)
+mockServer.RegisterFunc("version", DefaultVersion)
+
+mockServer.Start()
 ```
 
 

--- a/memcached.go
+++ b/memcached.go
@@ -59,9 +59,10 @@ func NewServer(addr string) *Server {
 	}
 }
 
-// Start starts a memcached server in a goroutine.
-// It listens on the TCP network address s.Addr and then calls Serve to handle requests
-// on incoming connections. Accepted connections are configured to enable TCP keep-alives.
+// Start starts the memcached server in a goroutine.
+// It listens on the TCP/unix network address s.Addr and then calls Serve to handle
+// requests on incoming connections. Accepted connections are configured to enable
+// TCP keep-alives when they are TCP network connections.
 func (s *Server) Start() error {
 	var err error
 

--- a/memcached.go
+++ b/memcached.go
@@ -66,7 +66,8 @@ func (s *Server) Start() error {
 	var err error
 
 	if strings.Contains(s.addr, "://") {
-		u, err := url.Parse(s.addr)
+		var u *url.URL
+		u, err = url.Parse(s.addr)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This pull request fixed an error propagation issue, updated the comment of the Start() method and the example code in the README.md to note that Unix domain socket is supported.